### PR TITLE
Let's make CellBinder's nib property optional.

### DIFF
--- a/DataSourceKit.xcodeproj/project.pbxproj
+++ b/DataSourceKit.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		553ACE5D21461F1700710FDF /* C.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553ACE5C21461F1700710FDF /* C.swift */; };
+		553ACE5F21461F4B00710FDF /* CCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553ACE5E21461F4B00710FDF /* CCollectionViewCell.swift */; };
+		553ACE6121461F7300710FDF /* CTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553ACE6021461F7300710FDF /* CTableViewCell.swift */; };
 		7F59442B213FA22E007300FC /* TableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F59442A213FA22E007300FC /* TableViewDataSource.swift */; };
 		7F9AEDAD213BBBA10092854F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F9AEDAC213BBBA10092854F /* AppDelegate.swift */; };
 		7F9AEDB4213BBBA30092854F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7F9AEDB3213BBBA30092854F /* Assets.xcassets */; };
@@ -89,6 +92,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		553ACE5C21461F1700710FDF /* C.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = C.swift; sourceTree = "<group>"; };
+		553ACE5E21461F4B00710FDF /* CCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCollectionViewCell.swift; sourceTree = "<group>"; };
+		553ACE6021461F7300710FDF /* CTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CTableViewCell.swift; sourceTree = "<group>"; };
 		7F59442A213FA22E007300FC /* TableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewDataSource.swift; sourceTree = "<group>"; };
 		7F9AEDAA213BBBA10092854F /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F9AEDAC213BBBA10092854F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -290,6 +296,9 @@
 				7FB64C1E213B5BC80071FC26 /* BCollectionViewCell.swift */,
 				7FC38D2E213FA8B3009FCEB1 /* BTableViewCell.xib */,
 				7FC38D30213FA8BC009FCEB1 /* BTableViewCell.swift */,
+				553ACE5C21461F1700710FDF /* C.swift */,
+				553ACE5E21461F4B00710FDF /* CCollectionViewCell.swift */,
+				553ACE6021461F7300710FDF /* CTableViewCell.swift */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -530,8 +539,11 @@
 				7FC38D29213FA6B7009FCEB1 /* B.swift in Sources */,
 				7FC38D33213FA908009FCEB1 /* TableViewDataSourceTests.swift in Sources */,
 				7FB64C1F213B5BC80071FC26 /* BCollectionViewCell.swift in Sources */,
+				553ACE5D21461F1700710FDF /* C.swift in Sources */,
 				7FB64C1D213B5BC20071FC26 /* ACollectionViewCell.swift in Sources */,
 				7FB64C1B213B59300071FC26 /* TestCollectionView.swift in Sources */,
+				553ACE6121461F7300710FDF /* CTableViewCell.swift in Sources */,
+				553ACE5F21461F4B00710FDF /* CCollectionViewCell.swift in Sources */,
 				7FC38D35213FA917009FCEB1 /* TestTableView.swift in Sources */,
 				7FC38D31213FA8BC009FCEB1 /* BTableViewCell.swift in Sources */,
 				7FC38D27213FA585009FCEB1 /* A.swift in Sources */,

--- a/DataSourceKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/DataSourceKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/DataSourceKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/DataSourceKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/DataSourceKit/CellBinder.swift
+++ b/DataSourceKit/CellBinder.swift
@@ -9,15 +9,24 @@
 import Foundation
 
 public struct CellBinder {
-    public let nib: UINib?
-    public let cellType: AnyClass?
+    
+    public enum RegistrationMethod {
+        case nib(UINib)
+        case `class`(AnyClass)
+        case none
+    }
+    
+    public let registrationMethod: RegistrationMethod
     public let reuseIdentifier: String
     
     internal let configureCell: (Any) -> Void
     
-    public init<Cell>(cellType: Cell.Type, nib: UINib?, reuseIdentifier: String, configureCell: @escaping (Cell) -> Void) {
-        self.nib = nib
-        self.cellType = cellType as? AnyClass
+    public init<Cell>(cellType: Cell.Type, reuseIdentifier: String, configureCell: @escaping (Cell) -> Void) {
+        self.init(cellType: cellType, registrationMethod: .class(cellType as! AnyClass), reuseIdentifier: reuseIdentifier, configureCell: configureCell)
+    }
+    
+    public init<Cell>(cellType: Cell.Type, registrationMethod: RegistrationMethod, reuseIdentifier: String, configureCell: @escaping (Cell) -> Void) {
+        self.registrationMethod = registrationMethod
         self.reuseIdentifier = reuseIdentifier
         self.configureCell = { cell in
             guard let cell = cell as? Cell else {
@@ -26,5 +35,10 @@ public struct CellBinder {
             
             configureCell(cell)
         }
+    }
+    
+    @available(*, deprecated, message:  "Use `init<Cell>(cellType: Cell.Type, registrationMethod: RegistrationMethod, reuseIdentifier: String, configureCell: @escaping (Cell) -> Void)` instead")
+    public init<Cell>(cellType: Cell.Type, nib: UINib?, reuseIdentifier: String, configureCell: @escaping (Cell) -> Void) {
+        fatalError("This method is deprecated, Use `init<Cell>(cellType: Cell.Type, registrationMethod: RegistrationMethod, reuseIdentifier: String, configureCell: @escaping (Cell) -> Void)` instead")
     }
 }

--- a/DataSourceKit/CellBinder.swift
+++ b/DataSourceKit/CellBinder.swift
@@ -9,13 +9,15 @@
 import Foundation
 
 public struct CellBinder {
-    public let nib: UINib
+    public let nib: UINib?
+    public let cellType: AnyClass?
     public let reuseIdentifier: String
     
     internal let configureCell: (Any) -> Void
     
-    public init<Cell>(cellType: Cell.Type, nib: UINib, reuseIdentifier: String, configureCell: @escaping (Cell) -> Void) {
+    public init<Cell>(cellType: Cell.Type, nib: UINib?, reuseIdentifier: String, configureCell: @escaping (Cell) -> Void) {
         self.nib = nib
+        self.cellType = cellType as? AnyClass
         self.reuseIdentifier = reuseIdentifier
         self.configureCell = { cell in
             guard let cell = cell as? Cell else {

--- a/DataSourceKit/CellBinder.swift
+++ b/DataSourceKit/CellBinder.swift
@@ -21,10 +21,6 @@ public struct CellBinder {
     
     internal let configureCell: (Any) -> Void
     
-    public init<Cell>(cellType: Cell.Type, reuseIdentifier: String, configureCell: @escaping (Cell) -> Void) {
-        self.init(cellType: cellType, registrationMethod: .class(cellType as! AnyClass), reuseIdentifier: reuseIdentifier, configureCell: configureCell)
-    }
-    
     public init<Cell>(cellType: Cell.Type, registrationMethod: RegistrationMethod, reuseIdentifier: String, configureCell: @escaping (Cell) -> Void) {
         self.registrationMethod = registrationMethod
         self.reuseIdentifier = reuseIdentifier

--- a/DataSourceKit/CollectionViewDataSource.swift
+++ b/DataSourceKit/CollectionViewDataSource.swift
@@ -26,7 +26,12 @@ public class CollectionViewDataSource<CellDeclaration>: NSObject, UICollectionVi
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cellBinder = binderFromDeclaration(cellDeclarations[indexPath.item])
         if !registeredReuseIdentifiers.contains(cellBinder.reuseIdentifier) {
-            collectionView.register(cellBinder.nib, forCellWithReuseIdentifier: cellBinder.reuseIdentifier)
+            
+            if let nib = cellBinder.nib {
+                collectionView.register(nib, forCellWithReuseIdentifier: cellBinder.reuseIdentifier)
+            } else {
+                collectionView.register(cellBinder.cellType, forCellWithReuseIdentifier: cellBinder.reuseIdentifier)
+            }
             registeredReuseIdentifiers.append(cellBinder.reuseIdentifier)
         }
         

--- a/DataSourceKit/CollectionViewDataSource.swift
+++ b/DataSourceKit/CollectionViewDataSource.swift
@@ -26,11 +26,13 @@ public class CollectionViewDataSource<CellDeclaration>: NSObject, UICollectionVi
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cellBinder = binderFromDeclaration(cellDeclarations[indexPath.item])
         if !registeredReuseIdentifiers.contains(cellBinder.reuseIdentifier) {
-            
-            if let nib = cellBinder.nib {
+            switch cellBinder.registrationMethod {
+            case let .nib(nib):
                 collectionView.register(nib, forCellWithReuseIdentifier: cellBinder.reuseIdentifier)
-            } else {
-                collectionView.register(cellBinder.cellType, forCellWithReuseIdentifier: cellBinder.reuseIdentifier)
+            case let .class(cellClass):
+                collectionView.register(cellClass, forCellWithReuseIdentifier: cellBinder.reuseIdentifier)
+            case .none:
+                break
             }
             registeredReuseIdentifiers.append(cellBinder.reuseIdentifier)
         }

--- a/DataSourceKit/TableViewDataSource.swift
+++ b/DataSourceKit/TableViewDataSource.swift
@@ -26,17 +26,18 @@ public class TableViewDataSource<CellDeclaration>: NSObject, UITableViewDataSour
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cellBinder = binderFromDeclaration(cellDeclarations[indexPath.item])
         if !registeredReuseIdentifiers.contains(cellBinder.reuseIdentifier) {
-            if let nib = cellBinder.nib {
+            switch cellBinder.registrationMethod {
+            case let .nib(nib):
                 tableView.register(nib, forCellReuseIdentifier: cellBinder.reuseIdentifier)
-            } else {
-                tableView.register(cellBinder.cellType, forCellReuseIdentifier: cellBinder.reuseIdentifier)
+            case let .class(cellClass):
+                tableView.register(cellClass, forCellReuseIdentifier: cellBinder.reuseIdentifier)
+            case .none:
+                break
             }
             registeredReuseIdentifiers.append(cellBinder.reuseIdentifier)
         }
-        
         let cell = tableView.dequeueReusableCell(withIdentifier: cellBinder.reuseIdentifier, for: indexPath)
         cellBinder.configureCell(cell)
-        
         return cell
     }
 }

--- a/DataSourceKit/TableViewDataSource.swift
+++ b/DataSourceKit/TableViewDataSource.swift
@@ -26,7 +26,11 @@ public class TableViewDataSource<CellDeclaration>: NSObject, UITableViewDataSour
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cellBinder = binderFromDeclaration(cellDeclarations[indexPath.item])
         if !registeredReuseIdentifiers.contains(cellBinder.reuseIdentifier) {
-            tableView.register(cellBinder.nib, forCellReuseIdentifier: cellBinder.reuseIdentifier)
+            if let nib = cellBinder.nib {
+                tableView.register(nib, forCellReuseIdentifier: cellBinder.reuseIdentifier)
+            } else {
+                tableView.register(cellBinder.cellType, forCellReuseIdentifier: cellBinder.reuseIdentifier)
+            }
             registeredReuseIdentifiers.append(cellBinder.reuseIdentifier)
         }
         

--- a/DataSourceKitTests/CollectionViewDataSourceTests.swift
+++ b/DataSourceKitTests/CollectionViewDataSourceTests.swift
@@ -14,11 +14,13 @@ class CollectionViewDataSourceTests: XCTestCase {
     enum CellDeclaration {
         case a(A)
         case b(B)
+        case c(C)
     }
     
     struct Data: CellsDeclarator {
         var a: [A]
         var b: [B]
+        var c: [C]
 
         func declareCells(_ cell: (CellDeclaration) -> Void) {
             for a in a {
@@ -26,6 +28,9 @@ class CollectionViewDataSourceTests: XCTestCase {
             }
             for b in b {
                 cell(.b(b))
+            }
+            for c in c {
+                cell(.c(c))
             }
         }
     }
@@ -42,6 +47,8 @@ class CollectionViewDataSourceTests: XCTestCase {
                 return ACollectionViewCell.makeBinder(value: a)
             case .b(let b):
                 return BCollectionViewCell.makeBinder(value: b)
+            case .c(let c):
+                return CCollectionViewCell.makeBinder(value: c)
             }
         }
         
@@ -50,13 +57,14 @@ class CollectionViewDataSourceTests: XCTestCase {
     }
 
     func test() {
-        let data = Data(a: [A(id: 1), A(id: 2)], b: [B(id: 1)])
+        let data = Data(a: [A(id: 1), A(id: 2)], b: [B(id: 1)], c: [C(id: 1)])
         dataSource.cellDeclarations = data.cellDeclarations
         collectionView.reloadData()
         collectionView.layoutIfNeeded()
         
-        XCTAssertEqual(dataSource.collectionView(collectionView, numberOfItemsInSection: 0), 3)
+        XCTAssertEqual(dataSource.collectionView(collectionView, numberOfItemsInSection: 0), 4)
         XCTAssertEqual(collectionView.nibRegistrations.map({ $0.reuseIdentifier }), ["ACollectionViewCell", "BCollectionViewCell"])
+        XCTAssertEqual(collectionView.classRegistrations.map({ $0.reuseIdentifier }), ["CCollectionViewCell"])
         
         let verifiers: [(UICollectionViewCell?) -> Void] = [
             { cell in
@@ -74,6 +82,11 @@ class CollectionViewDataSourceTests: XCTestCase {
                 XCTAssertNotNil(cell)
                 XCTAssertEqual(cell?.idLabel.text, "1")
             },
+            { cell in
+                let cell = cell as? CCollectionViewCell
+                XCTAssertNotNil(cell)
+                XCTAssertEqual(cell?.idLabel.text, "1")
+            }
         ]
         
         for (index, verifier) in verifiers.enumerated() {

--- a/DataSourceKitTests/Example/C.swift
+++ b/DataSourceKitTests/Example/C.swift
@@ -1,0 +1,13 @@
+//
+//  C.swift
+//  DataSourceKitTests
+//
+//  Created by zhzh liu on 2018/9/10.
+//  Copyright © 2018年 Yosuke Ishikawa. All rights reserved.
+//
+
+import Foundation
+
+struct C {
+    let id: Int64
+}

--- a/DataSourceKitTests/Example/CCollectionViewCell.swift
+++ b/DataSourceKitTests/Example/CCollectionViewCell.swift
@@ -1,0 +1,26 @@
+//
+//  CCollectionViewCell.swift
+//  DataSourceKitTests
+//
+//  Created by zhzh liu on 2018/9/10.
+//  Copyright © 2018年 Yosuke Ishikawa. All rights reserved.
+//
+
+import UIKit
+import DataSourceKit
+
+class CCollectionViewCell: UICollectionViewCell {
+    var idLabel = UILabel(frame: .zero)
+}
+
+extension CCollectionViewCell: BindableCell {
+    static func makeBinder(value: C) -> CellBinder {
+        return CellBinder(
+            cellType: CCollectionViewCell.self,
+            nib: nil,
+            reuseIdentifier: "CCollectionViewCell",
+            configureCell: { (cell) in
+                cell.idLabel.text = "\(value.id)"
+        })
+    }
+}

--- a/DataSourceKitTests/Example/CTableViewCell.swift
+++ b/DataSourceKitTests/Example/CTableViewCell.swift
@@ -1,0 +1,40 @@
+//
+//  CTableViewCell.swift
+//  DataSourceKitTests
+//
+//  Created by zhzh liu on 2018/9/10.
+//  Copyright © 2018年 Yosuke Ishikawa. All rights reserved.
+//
+
+import UIKit
+import DataSourceKit
+
+class CTableViewCell: UITableViewCell {
+    var idLabel = UILabel(frame: .zero)
+    
+    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        contentView.addSubview(idLabel)
+        idLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor)
+        idLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+        idLabel.heightAnchor.constraint(equalToConstant: 44.0)
+        idLabel.topAnchor.constraint(equalTo: contentView.topAnchor)
+        idLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError()
+    }
+}
+
+extension CTableViewCell: BindableCell {
+    static func makeBinder(value: C) -> CellBinder {
+        return CellBinder(
+            cellType: CTableViewCell.self,
+            nib: nil,
+            reuseIdentifier: "CTableViewCell",
+            configureCell: { (cell) in
+                cell.idLabel.text = "\(value.id)"
+        })
+    }
+}

--- a/DataSourceKitTests/TableViewDataSourceTests.swift
+++ b/DataSourceKitTests/TableViewDataSourceTests.swift
@@ -14,11 +14,13 @@ class TableViewDataSourceTests: XCTestCase {
     enum CellDeclaration {
         case a(A)
         case b(B)
+        case c(C)
     }
     
     struct Data: CellsDeclarator {
         var a: [A]
         var b: [B]
+        var c: [C]
         
         func declareCells(_ cell: (CellDeclaration) -> Void) {
             for a in a {
@@ -26,6 +28,9 @@ class TableViewDataSourceTests: XCTestCase {
             }
             for b in b {
                 cell(.b(b))
+            }
+            for c in c {
+                cell(.c(c))
             }
         }
     }
@@ -42,6 +47,8 @@ class TableViewDataSourceTests: XCTestCase {
                 return ATableViewCell.makeBinder(value: a)
             case .b(let b):
                 return BTableViewCell.makeBinder(value: b)
+            case .c(let c):
+                return CTableViewCell.makeBinder(value: c)
             }
         }
         
@@ -50,13 +57,14 @@ class TableViewDataSourceTests: XCTestCase {
     }
     
     func test() {
-        let data = Data(a: [A(id: 1), A(id: 2)], b: [B(id: 1)])
+        let data = Data(a: [A(id: 1), A(id: 2)], b: [B(id: 1)], c: [C(id: 1)])
         dataSource.cellDeclarations = data.cellDeclarations
         tableView.reloadData()
         tableView.layoutIfNeeded()
         
-        XCTAssertEqual(dataSource.tableView(tableView, numberOfRowsInSection: 0), 3)
+        XCTAssertEqual(dataSource.tableView(tableView, numberOfRowsInSection: 0), 4)
         XCTAssertEqual(tableView.nibRegistrations.map({ $0.reuseIdentifier }), ["ATableViewCell", "BTableViewCell"])
+        XCTAssertEqual(tableView.classRegistrations.map({ $0.reuseIdentifier }), ["CTableViewCell"])
         
         let verifiers: [(UITableViewCell?) -> Void] = [
             { cell in
@@ -74,6 +82,11 @@ class TableViewDataSourceTests: XCTestCase {
                 XCTAssertNotNil(cell)
                 XCTAssertEqual(cell?.idLabel.text, "1")
             },
+            { cell in
+                let cell = cell as? CTableViewCell
+                XCTAssertNotNil(cell)
+                XCTAssertEqual(cell?.idLabel.text, "1")
+            }
         ]
         
         for (index, verifier) in verifiers.enumerated() {

--- a/DataSourceKitTests/TestView/TestCollectionView.swift
+++ b/DataSourceKitTests/TestView/TestCollectionView.swift
@@ -14,12 +14,29 @@ class TestCollectionView: UICollectionView {
         let nib: UINib?
     }
     
+    struct ClassRegistration {
+        let reuseIdentifier: String
+        let cellType: AnyClass?
+    }
+    
     var nibRegistrations = [] as [NibRegistration]
+    var classRegistrations = [] as [ClassRegistration]
     
     override func register(_ nib: UINib?, forCellWithReuseIdentifier identifier: String) {
         super.register(nib, forCellWithReuseIdentifier: identifier)
         
         let nibRegistration = NibRegistration(reuseIdentifier: identifier, nib: nib)
         nibRegistrations.append(nibRegistration)
+    }
+    
+    override func register(_ cellClass: AnyClass?, forCellWithReuseIdentifier identifier: String) {
+        super.register(cellClass, forCellWithReuseIdentifier: identifier)
+        
+        // The `register(_ cellClass: forCellWithReuseIdentifier:)` method will be called and receiving a `"com.apple.UIKit.shadowReuseCellIdentifier"`
+        // reuse identifier when UICollectionView is initiated by `init(frame: collectionViewLayout:)`, I filter it out since it's useless for
+        // our testing.
+        if identifier == "com.apple.UIKit.shadowReuseCellIdentifier" { return }
+        let classRegistration = ClassRegistration(reuseIdentifier: identifier, cellType: cellClass)
+        classRegistrations.append(classRegistration)
     }
 }

--- a/DataSourceKitTests/TestView/TestTableView.swift
+++ b/DataSourceKitTests/TestView/TestTableView.swift
@@ -14,12 +14,25 @@ class TestTableView: UITableView {
         let nib: UINib?
     }
     
+    struct ClassRegistration {
+        let reuseIdentifier: String
+        let cellClass: AnyClass?
+    }
+    
     var nibRegistrations = [] as [NibRegistration]
+    var classRegistrations = [] as [ClassRegistration]
     
     override func register(_ nib: UINib?, forCellReuseIdentifier identifier: String) {
         super.register(nib, forCellReuseIdentifier: identifier)
 
         let nibRegistration = NibRegistration(reuseIdentifier: identifier, nib: nib)
         nibRegistrations.append(nibRegistration)
+    }
+    
+    override func register(_ cellClass: AnyClass?, forCellReuseIdentifier identifier: String) {
+        super.register(cellClass, forCellReuseIdentifier: identifier)
+        
+        let classRegistration = ClassRegistration(reuseIdentifier: identifier, cellClass: cellClass)
+        classRegistrations.append(classRegistration)
     }
 }

--- a/Demo/Cell/RelatedVenueCell.swift
+++ b/Demo/Cell/RelatedVenueCell.swift
@@ -28,7 +28,7 @@ extension RelatedVenueCell: BindableCell {
     static func makeBinder(value venue: Venue) -> CellBinder {
         return CellBinder(
             cellType: RelatedVenueCell.self,
-            nib: UINib(nibName: "RelatedVenueCell", bundle: nil),
+            registrationMethod: .nib(UINib(nibName: "RelatedVenueCell", bundle: nil)),
             reuseIdentifier: "RelatedVenue",
             configureCell: { cell in
                 cell.photoImageView.image = venue.photo

--- a/Demo/Cell/ReviewCell.swift
+++ b/Demo/Cell/ReviewCell.swift
@@ -19,7 +19,7 @@ extension ReviewCell: BindableCell {
     static func makeBinder(value review: Review) -> CellBinder {
         return CellBinder(
             cellType: ReviewCell.self,
-            nib: UINib(nibName: "ReviewCell", bundle: nil),
+            registrationMethod: .nib(UINib(nibName: "ReviewCell", bundle: nil)),
             reuseIdentifier: "Review",
             configureCell: { cell in
                 cell.authorImageView.image = review.authorImage

--- a/Demo/Cell/SectionHeaderCell.swift
+++ b/Demo/Cell/SectionHeaderCell.swift
@@ -17,7 +17,7 @@ extension SectionHeaderCell: BindableCell {
     static func makeBinder(value title: String) -> CellBinder {
         return CellBinder(
             cellType: SectionHeaderCell.self,
-            nib: UINib(nibName: "SectionHeaderCell", bundle: nil),
+            registrationMethod: .nib(UINib(nibName: "SectionHeaderCell", bundle: nil)),
             reuseIdentifier: "SectionHeader",
             configureCell: { cell in
                 cell.titleLabel.text = title

--- a/Demo/Cell/VenueOutlineCell.swift
+++ b/Demo/Cell/VenueOutlineCell.swift
@@ -18,7 +18,7 @@ extension VenueOutlineCell: BindableCell {
     static func makeBinder(value venue: Venue) -> CellBinder {
         return CellBinder(
             cellType: VenueOutlineCell.self,
-            nib: UINib(nibName: "VenueOutlineCell", bundle: nil),
+            registrationMethod: .nib(UINib(nibName: "VenueOutlineCell", bundle: nil)),
             reuseIdentifier: "VenueOutline",
             configureCell: { cell in
                 cell.photoImageView.image = venue.photo


### PR DESCRIPTION
In this Pull Request, I do some changes to the `CellBinder` class.
- Change `nib` property to optional
-  Add a `cellType: AnyClass?` property

So we can implement our Cell without using a Nib.