### PR TITLE
Add support for supplementary views

### DIFF
--- a/DataSourceKit/CollectionViewDataSource.swift
+++ b/DataSourceKit/CollectionViewDataSource.swift
@@ -8,13 +8,13 @@
 
 import UIKit
 
-open class CollectionViewDataSource<CellDeclaration>: NSObject, UICollectionViewDataSource {
+public class CollectionViewDataSource<CellDeclaration>: NSObject, UICollectionViewDataSource {
     public var cellDeclarations = [] as [CellDeclaration]
-    
+    public typealias ConfigureSupplementaryView = (CollectionViewDataSource<CellDeclaration>, UICollectionView, String, IndexPath) -> UICollectionReusableView
+    public var configureSupplementaryView: ConfigureSupplementaryView?
+
     private var registeredReuseIdentifiers = [] as [String]
     private let binderFromDeclaration: (CellDeclaration) -> CellBinder
-    public typealias ConfigureSupplementaryView = (CollectionViewDataSource<CellDeclaration>, UICollectionView, String, IndexPath) -> UICollectionReusableView
-    open var configureSupplementaryView: ConfigureSupplementaryView?
 
     public init(binderFromDeclaration: @escaping (CellDeclaration) -> CellBinder) {
         self.binderFromDeclaration = binderFromDeclaration
@@ -47,14 +47,17 @@ open class CollectionViewDataSource<CellDeclaration>: NSObject, UICollectionView
 
 
     public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        return configureSupplementaryView!(self, collectionView, kind, indexPath)
+        guard let configureSupplementaryView = self.configureSupplementaryView else {
+            return UICollectionReusableView()
+        }
+        return configureSupplementaryView(self, collectionView, kind, indexPath)
     }
 
-    open override func responds(to aSelector: Selector!) -> Bool {
+    public override func responds(to aSelector: Selector!) -> Bool {
         if aSelector == #selector(UICollectionViewDataSource.collectionView(_:viewForSupplementaryElementOfKind:at:)) {
             return configureSupplementaryView != nil
-        } else {
-            return super.responds(to: aSelector)
         }
+
+        return super.responds(to: aSelector)
     }
 }

--- a/DataSourceKit/CollectionViewDataSource.swift
+++ b/DataSourceKit/CollectionViewDataSource.swift
@@ -8,17 +8,19 @@
 
 import UIKit
 
-public class CollectionViewDataSource<CellDeclaration>: NSObject, UICollectionViewDataSource {
+open class CollectionViewDataSource<CellDeclaration>: NSObject, UICollectionViewDataSource {
     public var cellDeclarations = [] as [CellDeclaration]
     
     private var registeredReuseIdentifiers = [] as [String]
     private let binderFromDeclaration: (CellDeclaration) -> CellBinder
-    
+    public typealias ConfigureSupplementaryView = (CollectionViewDataSource<CellDeclaration>, UICollectionView, String, IndexPath) -> UICollectionReusableView
+    open var configureSupplementaryView: ConfigureSupplementaryView?
+
     public init(binderFromDeclaration: @escaping (CellDeclaration) -> CellBinder) {
         self.binderFromDeclaration = binderFromDeclaration
         super.init()
     }
-    
+
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return cellDeclarations.count
     }
@@ -41,5 +43,18 @@ public class CollectionViewDataSource<CellDeclaration>: NSObject, UICollectionVi
         cellBinder.configureCell(cell)
         
         return cell
+    }
+
+
+    public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        return configureSupplementaryView!(self, collectionView, kind, indexPath)
+    }
+
+    open override func responds(to aSelector: Selector!) -> Bool {
+        if aSelector == #selector(UICollectionViewDataSource.collectionView(_:viewForSupplementaryElementOfKind:at:)) {
+            return configureSupplementaryView != nil
+        } else {
+            return super.responds(to: aSelector)
+        }
     }
 }


### PR DESCRIPTION
This adds support for supplementary views in collection views. If the user sets the configureSupplementaryView closure the given implementation will be called in viewForSupplementaryView:. If the implementation is not given and the closure is nil the collection view datasource will behave just like it did before. So this is a non breaking change but it makes the datasource more powerful by providing the ability to create more complex collection view layouts.

The following code snippets shows the usage:
```swift
dataSource.configureSupplementaryView = { dataSource, collectionView, kind, indexPath in
    let separatorView = collectionView.dequeueReusableSupplementaryView(ofKind: SeparatorView.kindIdentifier, withReuseIdentifier: SeparatorView.kindIdentifier, for: indexPath)
    return separatorView
}
 ```